### PR TITLE
Add missing includes (avoid relying on transitive includes)

### DIFF
--- a/rerun_bridge/include/rerun_bridge/rerun_ros_interface.hpp
+++ b/rerun_bridge/include/rerun_bridge/rerun_ros_interface.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <map>
+#include <string>
+
 #include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/TransformStamped.h>
 #include <nav_msgs/Odometry.h>

--- a/rerun_bridge/src/rerun_bridge/visualizer_node.hpp
+++ b/rerun_bridge/src/rerun_bridge/visualizer_node.hpp
@@ -4,6 +4,7 @@
 #include <string>
 
 #include <ros/ros.h>
+#include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 #include <yaml-cpp/yaml.h>
 #include <rerun.hpp>


### PR DESCRIPTION
Was relying on some transitive includes.