### PR TITLE
Fix extra_pinhole and drone example

### DIFF
--- a/rerun_bridge/launch/drone_example_params.yaml
+++ b/rerun_bridge/launch/drone_example_params.yaml
@@ -1,6 +1,7 @@
 topic_to_entity_path:
   /snappy_cam/stereo_l: /groundtruth/pose/snappy_cam/stereo_l
   /snappy_cam/stereo_r: /groundtruth/pose/snappy_cam/stereo_r
+  /groundtruth/pose: /groundtruth/pose
 extra_transform3ds:
   - entity_path: /groundtruth/pose/snappy_cam/stereo_l
     transform: [

--- a/rerun_bridge/src/rerun_bridge/visualizer_node.cpp
+++ b/rerun_bridge/src/rerun_bridge/visualizer_node.cpp
@@ -114,6 +114,30 @@ void RerunLoggerNode::_read_yaml_config(std::string yaml_path) {
             );
         }
     }
+    if (config["extra_pinholes"]) {
+        for (const auto& extra_pinhole : config["extra_pinholes"]) {
+            // Rerun uses column-major order for Mat3x3
+            const std::array<float, 9> image_from_camera = {
+                extra_pinhole["image_from_camera"][0].as<float>(),
+                extra_pinhole["image_from_camera"][3].as<float>(),
+                extra_pinhole["image_from_camera"][6].as<float>(),
+                extra_pinhole["image_from_camera"][1].as<float>(),
+                extra_pinhole["image_from_camera"][4].as<float>(),
+                extra_pinhole["image_from_camera"][7].as<float>(),
+                extra_pinhole["image_from_camera"][2].as<float>(),
+                extra_pinhole["image_from_camera"][5].as<float>(),
+                extra_pinhole["image_from_camera"][8].as<float>(),
+            };
+            _rec.log_static(
+                extra_pinhole["entity_path"].as<std::string>(),
+                rerun::Pinhole(image_from_camera)
+                    .with_resolution(
+                        extra_pinhole["width"].as<int>(),
+                        extra_pinhole["height"].as<int>()
+                    )
+            );
+        }
+    }
     if (config["tf"]) {
         if (config["tf"]["update_rate"]) {
             _tf_fixed_rate = config["tf"]["update_rate"].as<float>();


### PR DESCRIPTION
Drone example has been broken since #4, which added a `/topic` prefix and accidentally removed handling of `extra_pinhole`.